### PR TITLE
Change url to hub.docker.com

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -95,7 +95,7 @@ push_readme() {
   local code=$(jq -n --arg msg "$(<${file_name})" \
     '{"registry":"registry-1.docker.io","full_description": $msg }' | \
         curl -s -o /dev/null  -L -w "%{http_code}" \
-           https://cloud.docker.com/v2/repositories/"${image}"/ \
+           https://hub.docker.com/v2/repositories/"${image}"/ \
            -d @- -X PATCH \
            -H "Content-Type: application/json" \
            -H "Authorization: JWT ${token}")


### PR DESCRIPTION
Hi @moikot,

I am using a variant of your code in another repository and noticed that about four days ago my publish was failing since it could not update the readme. I looked into the related code and switching the url to hub.docker.com (instead of cloud.docker.com) makes the update succeed again.

It's a bit strange since curl is already instructed to follow redirects, so it should have been fine.